### PR TITLE
Fixed <p> elements with children

### DIFF
--- a/lib/notustohtml.dart
+++ b/lib/notustohtml.dart
@@ -314,10 +314,10 @@ class _NotusHtmlDecoder extends Converter<String, Delta> {
 
   Delta _parseElement(Element element, Delta delta, String type,
       {Map<String, dynamic> attributes,
-        String listType,
-        next,
-        inList,
-        inBlock}) {
+      String listType,
+      next,
+      inList,
+      inBlock}) {
     if (type == "block") {
       Map<String, dynamic> blockAttributes = {};
       if (inBlock != null) blockAttributes = inBlock;

--- a/lib/notustohtml.dart
+++ b/lib/notustohtml.dart
@@ -61,11 +61,6 @@ class _NotusHtmlEncoder extends Converter<Delta, String> {
         buffer.write("</li>");
         _writeAttribute(buffer, blockStyle, close: true);
         buffer.writeln();
-      } else if (blockStyle.value == "p") {
-        buffer.write("<p>");
-        buffer.write(currentBlockLines.join(''));
-        buffer.write("</p>");
-        buffer.writeln();
       } else {
         for (var line in currentBlockLines) {
           _writeBlockTag(buffer, blockStyle);

--- a/test/notustohtml_test.dart
+++ b/test/notustohtml_test.dart
@@ -109,14 +109,14 @@ void main() {
 
     group('Blocks', () {
       test("Paragraph Element", () {
-        final String html = "<p>Hello World!</p><br><br>";
+        final String html = "Hello World!<br><br>";
         final NotusDocument doc = NotusDocument.fromJson([
           {
             "insert": "Hello World!",
           },
           {
             "insert": "\n",
-            "attributes": {"block": "p"},
+            "attributes": {},
           }
         ]);
 
@@ -137,7 +137,7 @@ void main() {
           },
           {
             "insert": "\n",
-            "attributes": {"block": "p"},
+            "attributes": {},
           }
         ]);
 
@@ -159,7 +159,7 @@ void main() {
           },
           {
             "insert": "\n",
-            "attributes": {"block": "p"},
+            "attributes": {},
           },
           {
             "insert": "Hello World!",
@@ -173,7 +173,7 @@ void main() {
           },
           {
             "insert": "\n",
-            "attributes": {"block": "p"},
+            "attributes": {},
           }
         ]);
 
@@ -440,7 +440,7 @@ void main() {
           },
           {
             "insert": "\n",
-            "attributes": {"block": "p"},
+            "attributes": {},
           }
         ]);
 
@@ -461,7 +461,7 @@ void main() {
           },
           {
             "insert": "\n",
-            "attributes": {"block": "p"},
+            "attributes": {},
           }
         ]);
 
@@ -483,7 +483,7 @@ void main() {
           },
           {
             "insert": "\n",
-            "attributes": {"block": "p"},
+            "attributes": {},
           },
           {
             "insert": "Hello World!",
@@ -497,7 +497,7 @@ void main() {
           },
           {
             "insert": "\n",
-            "attributes": {"block": "p"},
+            "attributes": {},
           }
         ]);
 

--- a/test/notustohtml_test.dart
+++ b/test/notustohtml_test.dart
@@ -13,7 +13,8 @@ void main() {
           {"insert": "Hello World!\n"}
         ]);
 
-        expect(converter.encode(doc.toDelta()), "Hello World!<br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "Hello World!<br><br>");
       });
 
       test("Bold paragraph", () {
@@ -24,7 +25,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<strong>Hello World!</strong><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<strong>Hello World!</strong><br><br>");
       });
 
       test("Italic paragraph", () {
@@ -35,7 +37,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<em>Hello World!</em><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<em>Hello World!</em><br><br>");
       });
 
       test("Bold and Italic paragraph", () {
@@ -46,7 +49,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<em><strong>Hello World!</em></strong><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<em><strong>Hello World!</em></strong><br><br>");
       });
     });
 
@@ -60,7 +64,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<h1>Hello World!</h1><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<h1>Hello World!</h1><br><br>");
       });
 
       test("2", () {
@@ -72,7 +77,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<h2>Hello World!</h2><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<h2>Hello World!</h2><br><br>");
       });
 
       test("3", () {
@@ -84,7 +90,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<h3>Hello World!</h3><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<h3>Hello World!</h3><br><br>");
       });
 
       test("In list", () {
@@ -96,7 +103,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<ul><li><h1>Hello World!</h1></li></ul><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<ul><li><h1>Hello World!</h1></li></ul><br><br>");
       });
     });
 
@@ -181,7 +189,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<blockquote>Hello World!</blockquote><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<blockquote>Hello World!</blockquote><br><br>");
       });
       test("Code", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -192,7 +201,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<br><code>Hello World!</code><br><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<br><code>Hello World!</code><br><br><br>");
       });
       test("Ordered list", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -203,7 +213,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<ol><li>Hello World!</li></ol><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<ol><li>Hello World!</li></ol><br><br>");
       });
       test("List with bold", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -217,7 +228,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<ol><li><strong>Hello World!</strong></li></ol><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<ol><li><strong>Hello World!</strong></li></ol><br><br>");
       });
       test("Unordered list", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -233,7 +245,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<ul><li>Hello World!</li><li>Hello World!</li></ul><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<ul><li>Hello World!</li><li>Hello World!</li></ul><br><br>");
       });
     });
 
@@ -252,7 +265,8 @@ void main() {
           {"insert": "\n"}
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<img src=\"http://fake.link/image.png\"><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<img src=\"http://fake.link/image.png\"><br><br>");
       });
       test("Line", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -281,7 +295,8 @@ void main() {
           {"insert": "\n"}
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<a href=\"http://fake.link\">Hello World!</a><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<a href=\"http://fake.link\">Hello World!</a><br><br>");
       });
 
       test("Italic", () {
@@ -293,7 +308,8 @@ void main() {
           {"insert": "\n"}
         ]);
 
-        expect(converter.encode(doc.toDelta()), "<a href=\"http://fake.link\"><em>Hello World!</em></a><br><br>");
+        expect(converter.encode(doc.toDelta()),
+            "<a href=\"http://fake.link\"><em>Hello World!</em></a><br><br>");
       });
 
       test("In list", () {
@@ -309,7 +325,8 @@ void main() {
         ]);
 
         expect(
-            converter.encode(doc.toDelta()), "<ul><li><a href=\"http://fake.link\">Hello World!</a></li></ul><br><br>");
+            converter.encode(doc.toDelta()),
+            "<ul><li><a href=\"http://fake.link\">Hello World!</a></li></ul><br><br>");
       });
     });
   });
@@ -564,7 +581,8 @@ void main() {
         final delta = Delta()..insert("\n");
         NotusDocument tempdocument = NotusDocument.fromDelta(delta);
         var index = tempdocument.length;
-        tempdocument.format(index - 1, 0, NotusAttribute.embed.image("http://fake.link/image.png"));
+        tempdocument.format(index - 1, 0,
+            NotusAttribute.embed.image("http://fake.link/image.png"));
         final NotusDocument doc = tempdocument;
 
         expect(converter.decode(html), doc.toDelta());
@@ -574,7 +592,8 @@ void main() {
         final delta = Delta()..insert("\n");
         NotusDocument tempdocument = NotusDocument.fromDelta(delta);
         var index = tempdocument.length;
-        tempdocument.format(index - 1, 0, NotusAttribute.embed.horizontalRule);
+        tempdocument.format(index - 1, 0,
+            NotusAttribute.embed.horizontalRule);
         final NotusDocument doc = tempdocument;
 
         expect(converter.decode(html), doc.toDelta());

--- a/test/notustohtml_test.dart
+++ b/test/notustohtml_test.dart
@@ -13,8 +13,7 @@ void main() {
           {"insert": "Hello World!\n"}
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "Hello World!<br><br>");
+        expect(converter.encode(doc.toDelta()), "Hello World!<br><br>");
       });
 
       test("Bold paragraph", () {
@@ -37,8 +36,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<em>Hello World!</em><br><br>");
+        expect(
+            converter.encode(doc.toDelta()), "<em>Hello World!</em><br><br>");
       });
 
       test("Bold and Italic paragraph", () {
@@ -64,8 +63,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<h1>Hello World!</h1><br><br>");
+        expect(
+            converter.encode(doc.toDelta()), "<h1>Hello World!</h1><br><br>");
       });
 
       test("2", () {
@@ -77,8 +76,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<h2>Hello World!</h2><br><br>");
+        expect(
+            converter.encode(doc.toDelta()), "<h2>Hello World!</h2><br><br>");
       });
 
       test("3", () {
@@ -90,8 +89,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<h3>Hello World!</h3><br><br>");
+        expect(
+            converter.encode(doc.toDelta()), "<h3>Hello World!</h3><br><br>");
       });
 
       test("In list", () {
@@ -324,8 +323,7 @@ void main() {
           }
         ]);
 
-        expect(
-            converter.encode(doc.toDelta()),
+        expect(converter.encode(doc.toDelta()),
             "<ul><li><a href=\"http://fake.link\">Hello World!</a></li></ul><br><br>");
       });
     });

--- a/test/notustohtml_test.dart
+++ b/test/notustohtml_test.dart
@@ -24,8 +24,7 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<strong>Hello World!</strong><br><br>");
+        expect(converter.encode(doc.toDelta()), "<strong>Hello World!</strong><br><br>");
       });
 
       test("Italic paragraph", () {
@@ -36,8 +35,7 @@ void main() {
           }
         ]);
 
-        expect(
-            converter.encode(doc.toDelta()), "<em>Hello World!</em><br><br>");
+        expect(converter.encode(doc.toDelta()), "<em>Hello World!</em><br><br>");
       });
 
       test("Bold and Italic paragraph", () {
@@ -48,8 +46,7 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<em><strong>Hello World!</em></strong><br><br>");
+        expect(converter.encode(doc.toDelta()), "<em><strong>Hello World!</em></strong><br><br>");
       });
     });
 
@@ -63,8 +60,7 @@ void main() {
           }
         ]);
 
-        expect(
-            converter.encode(doc.toDelta()), "<h1>Hello World!</h1><br><br>");
+        expect(converter.encode(doc.toDelta()), "<h1>Hello World!</h1><br><br>");
       });
 
       test("2", () {
@@ -76,8 +72,7 @@ void main() {
           }
         ]);
 
-        expect(
-            converter.encode(doc.toDelta()), "<h2>Hello World!</h2><br><br>");
+        expect(converter.encode(doc.toDelta()), "<h2>Hello World!</h2><br><br>");
       });
 
       test("3", () {
@@ -89,8 +84,7 @@ void main() {
           }
         ]);
 
-        expect(
-            converter.encode(doc.toDelta()), "<h3>Hello World!</h3><br><br>");
+        expect(converter.encode(doc.toDelta()), "<h3>Hello World!</h3><br><br>");
       });
 
       test("In list", () {
@@ -102,12 +96,82 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<ul><li><h1>Hello World!</h1></li></ul><br><br>");
+        expect(converter.encode(doc.toDelta()), "<ul><li><h1>Hello World!</h1></li></ul><br><br>");
       });
     });
 
     group('Blocks', () {
+      test("Paragraph Element", () {
+        final String html = "<p>Hello World!</p><br><br>";
+        final NotusDocument doc = NotusDocument.fromJson([
+          {
+            "insert": "Hello World!",
+          },
+          {
+            "insert": "\n",
+            "attributes": {"block": "p"},
+          }
+        ]);
+
+        expect(converter.encode(doc.toDelta()), html);
+      });
+      test("Paragraph Element with children elements", () {
+        final String html = "<p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p><br><br>";
+        final NotusDocument doc = NotusDocument.fromJson([
+          {
+            "insert": "Hello World!",
+          },
+          {
+            "insert": "Hello World!",
+            "attributes": {"a": "http://fake.link"},
+          },
+          {
+            "insert": " Another hello world!",
+          },
+          {
+            "insert": "\n",
+            "attributes": {"block": "p"},
+          }
+        ]);
+
+        expect(converter.decode(html), doc.toDelta());
+      });
+      test("Multiples paragraps with children", () {
+        final String html =
+            "<p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p><br><br><p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p><br><br>";
+        final NotusDocument doc = NotusDocument.fromJson([
+          {
+            "insert": "Hello World!",
+          },
+          {
+            "insert": "Hello World!",
+            "attributes": {"a": "http://fake.link"},
+          },
+          {
+            "insert": " Another hello world!",
+          },
+          {
+            "insert": "\n",
+            "attributes": {"block": "p"},
+          },
+          {
+            "insert": "Hello World!",
+          },
+          {
+            "insert": "Hello World!",
+            "attributes": {"a": "http://fake.link"},
+          },
+          {
+            "insert": " Another hello world!",
+          },
+          {
+            "insert": "\n",
+            "attributes": {"block": "p"},
+          }
+        ]);
+
+        expect(converter.decode(html), doc.toDelta());
+      });
       test("Quote", () {
         final NotusDocument doc = NotusDocument.fromJson([
           {"insert": "Hello World!"},
@@ -117,8 +181,7 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<blockquote>Hello World!</blockquote><br><br>");
+        expect(converter.encode(doc.toDelta()), "<blockquote>Hello World!</blockquote><br><br>");
       });
       test("Code", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -129,8 +192,7 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<br><code>Hello World!</code><br><br><br>");
+        expect(converter.encode(doc.toDelta()), "<br><code>Hello World!</code><br><br><br>");
       });
       test("Ordered list", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -141,8 +203,7 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<ol><li>Hello World!</li></ol><br><br>");
+        expect(converter.encode(doc.toDelta()), "<ol><li>Hello World!</li></ol><br><br>");
       });
       test("List with bold", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -156,8 +217,7 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<ol><li><strong>Hello World!</strong></li></ol><br><br>");
+        expect(converter.encode(doc.toDelta()), "<ol><li><strong>Hello World!</strong></li></ol><br><br>");
       });
       test("Unordered list", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -173,8 +233,7 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<ul><li>Hello World!</li><li>Hello World!</li></ul><br><br>");
+        expect(converter.encode(doc.toDelta()), "<ul><li>Hello World!</li><li>Hello World!</li></ul><br><br>");
       });
     });
 
@@ -193,8 +252,7 @@ void main() {
           {"insert": "\n"}
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<img src=\"http://fake.link/image.png\"><br><br>");
+        expect(converter.encode(doc.toDelta()), "<img src=\"http://fake.link/image.png\"><br><br>");
       });
       test("Line", () {
         final NotusDocument doc = NotusDocument.fromJson([
@@ -223,8 +281,7 @@ void main() {
           {"insert": "\n"}
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<a href=\"http://fake.link\">Hello World!</a><br><br>");
+        expect(converter.encode(doc.toDelta()), "<a href=\"http://fake.link\">Hello World!</a><br><br>");
       });
 
       test("Italic", () {
@@ -236,8 +293,7 @@ void main() {
           {"insert": "\n"}
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<a href=\"http://fake.link\"><em>Hello World!</em></a><br><br>");
+        expect(converter.encode(doc.toDelta()), "<a href=\"http://fake.link\"><em>Hello World!</em></a><br><br>");
       });
 
       test("In list", () {
@@ -252,8 +308,8 @@ void main() {
           }
         ]);
 
-        expect(converter.encode(doc.toDelta()),
-            "<ul><li><a href=\"http://fake.link\">Hello World!</a></li></ul><br><br>");
+        expect(
+            converter.encode(doc.toDelta()), "<ul><li><a href=\"http://fake.link\">Hello World!</a></li></ul><br><br>");
       });
     });
   });
@@ -361,6 +417,77 @@ void main() {
     });
 
     group('Blocks', () {
+      test("Paragraph Element", () {
+        final String html = "<p>Hello World!</p>";
+        final NotusDocument doc = NotusDocument.fromJson([
+          {
+            "insert": "Hello World!",
+          },
+          {
+            "insert": "\n",
+            "attributes": {"block": "p"},
+          }
+        ]);
+
+        expect(converter.decode(html), doc.toDelta());
+      });
+      test("Paragraph Element with children elements", () {
+        final String html = "<p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p>";
+        final NotusDocument doc = NotusDocument.fromJson([
+          {
+            "insert": "Hello World!",
+          },
+          {
+            "insert": "Hello World!",
+            "attributes": {"a": "http://fake.link"},
+          },
+          {
+            "insert": " Another hello world!",
+          },
+          {
+            "insert": "\n",
+            "attributes": {"block": "p"},
+          }
+        ]);
+
+        expect(converter.decode(html), doc.toDelta());
+      });
+      test("Multiples paragraps with children", () {
+        final String html =
+            "<p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p><p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p>";
+        final NotusDocument doc = NotusDocument.fromJson([
+          {
+            "insert": "Hello World!",
+          },
+          {
+            "insert": "Hello World!",
+            "attributes": {"a": "http://fake.link"},
+          },
+          {
+            "insert": " Another hello world!",
+          },
+          {
+            "insert": "\n",
+            "attributes": {"block": "p"},
+          },
+          {
+            "insert": "Hello World!",
+          },
+          {
+            "insert": "Hello World!",
+            "attributes": {"a": "http://fake.link"},
+          },
+          {
+            "insert": " Another hello world!",
+          },
+          {
+            "insert": "\n",
+            "attributes": {"block": "p"},
+          }
+        ]);
+
+        expect(converter.decode(html), doc.toDelta());
+      });
       test("Quote", () {
         final String html = "<blockquote>Hello World!</blockquote><br><br>";
         final NotusDocument doc = NotusDocument.fromJson([
@@ -437,8 +564,7 @@ void main() {
         final delta = Delta()..insert("\n");
         NotusDocument tempdocument = NotusDocument.fromDelta(delta);
         var index = tempdocument.length;
-        tempdocument.format(index - 1, 0,
-            NotusAttribute.embed.image("http://fake.link/image.png"));
+        tempdocument.format(index - 1, 0, NotusAttribute.embed.image("http://fake.link/image.png"));
         final NotusDocument doc = tempdocument;
 
         expect(converter.decode(html), doc.toDelta());
@@ -448,8 +574,7 @@ void main() {
         final delta = Delta()..insert("\n");
         NotusDocument tempdocument = NotusDocument.fromDelta(delta);
         var index = tempdocument.length;
-        tempdocument.format(index - 1, 0,
-            NotusAttribute.embed.horizontalRule);
+        tempdocument.format(index - 1, 0, NotusAttribute.embed.horizontalRule);
         final NotusDocument doc = tempdocument;
 
         expect(converter.decode(html), doc.toDelta());

--- a/test/notustohtml_test.dart
+++ b/test/notustohtml_test.dart
@@ -122,63 +122,7 @@ void main() {
 
         expect(converter.encode(doc.toDelta()), html);
       });
-      test("Paragraph Element with children elements", () {
-        final String html = "<p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p><br><br>";
-        final NotusDocument doc = NotusDocument.fromJson([
-          {
-            "insert": "Hello World!",
-          },
-          {
-            "insert": "Hello World!",
-            "attributes": {"a": "http://fake.link"},
-          },
-          {
-            "insert": " Another hello world!",
-          },
-          {
-            "insert": "\n",
-            "attributes": {},
-          }
-        ]);
 
-        expect(converter.decode(html), doc.toDelta());
-      });
-      test("Multiples paragraps with children", () {
-        final String html =
-            "<p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p><br><br><p>Hello World!<a href=\"http://fake.link\">Hello World!</a> Another hello world!</p><br><br>";
-        final NotusDocument doc = NotusDocument.fromJson([
-          {
-            "insert": "Hello World!",
-          },
-          {
-            "insert": "Hello World!",
-            "attributes": {"a": "http://fake.link"},
-          },
-          {
-            "insert": " Another hello world!",
-          },
-          {
-            "insert": "\n",
-            "attributes": {},
-          },
-          {
-            "insert": "Hello World!",
-          },
-          {
-            "insert": "Hello World!",
-            "attributes": {"a": "http://fake.link"},
-          },
-          {
-            "insert": " Another hello world!",
-          },
-          {
-            "insert": "\n",
-            "attributes": {},
-          }
-        ]);
-
-        expect(converter.decode(html), doc.toDelta());
-      });
       test("Quote", () {
         final NotusDocument doc = NotusDocument.fromJson([
           {"insert": "Hello World!"},


### PR DESCRIPTION
I use a WYSIWYG editor on my Vue.js client, and I want my Flutter app to use Zefyr to be able to send HTML to our API. What I saw was that \<p\> HTML tags with children were not rendered correctly. If you tried to decode:
```
<p>Hello, visit <a href="https://google.com">google</a> to search through internet</p>
```
it was only encoded into a Delta document with the link.

I've changed \<p\> tag to be a block. I think it is better, because \<p\> is used to delimiter paragraphs, and in CSS they are blocks. I've done a few tests to ensure it is encoded and decoded correctly. 

Hope it helps!